### PR TITLE
Add comment clarifying how the state is modified

### DIFF
--- a/CounterExample/Reducers/CounterReducer.swift
+++ b/CounterExample/Reducers/CounterReducer.swift
@@ -7,8 +7,9 @@ struct CounterReducer: Reducer {
 
     
     func handleAction(action: Action, state: AppState?) -> AppState {
-        
         // if no state has been provided, create the default state
+        // otherwise the state is recreated every time, i.e. the
+        // current state is copied, modified and returned as the new state
         var state = state ?? AppState()
         
         switch action {


### PR DESCRIPTION
It's difficult to understand just by looking at the code of `CounterReducer` if the current state of the app is modified in-place or recreated.

This adds a comment to clarify that.